### PR TITLE
fix 'unused return' of readlink when compiling

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -543,7 +543,9 @@ static void afc_upload_dir(afc_client_t afc, const char* path, const char* afcpa
 #ifdef HAVE_LSTAT
 			if ((lstat(fpath, &st) == 0) && S_ISLNK(st.st_mode)) {
 				char *target = (char *)malloc(st.st_size);
-				readlink(fpath, target, st.st_size);
+				if(readlink(fpath, target, st.st_size)==-1){
+					fprintf(stderr, "Error: readlink error %s\n", strerror(errno));
+				};
 				afc_make_link(afc, AFC_SYMLINK, target, fpath);
 				free(target);
 			} else


### PR DESCRIPTION
make use of the return value of readlink and print error if occurred
