### PR TITLE
Fix compiling against libimobiledevice 1.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,13 +24,17 @@ PKG_CHECK_MODULES(libimobiledevice110, libimobiledevice-1.0 >= 1.1.0, libimobile
 if test x"$libimobiledevice_1_1" = xyes; then
   AC_DEFINE([HAVE_LIBIMOBILEDEVICE_1_1], 1, [Define if libimobiledevice is using 1.1.0 API])
 fi
-PKG_CHECK_MODULES(libimobiledevice112, libimobiledevice-1.0 >= 1.1.2, libimobiledevice_1_2=yes, libimobiledevice_1_2=no)
-if test x"$libimobiledevice_1_2" = xno; then
+PKG_CHECK_MODULES(libimobiledevice112, libimobiledevice-1.0 >= 1.1.2, libimobiledevice_1_1_2=yes, libimobiledevice_1_1_2=no)
+if test x"$libimobiledevice_1_1_2" = xno; then
   PKG_CHECK_MODULES(libglib2, glib-2.0 >= 2.14.1)
 fi
 PKG_CHECK_MODULES(libimobiledevice115, libimobiledevice-1.0 >= 1.1.5, libimobiledevice_1_1_5=yes, libimobiledevice_1_1_5=no)
 if test x"$libimobiledevice_1_1_5" = xyes; then
   AC_DEFINE([HAVE_LIBIMOBILEDEVICE_1_1_5], 1, [Define if libimobiledevice is using 1.1.5 API])
+fi
+PKG_CHECK_MODULES(libimobiledevice120, libimobiledevice-1.0 >= 1.2.0, libimobiledevice_1_2=yes, libimobiledevice_1_2=no)
+if test x"$libimobiledevice_1_2" = xyes; then
+  AC_DEFINE([HAVE_LIBIMOBILEDEVICE_1_2], 1, [Define if libimobiledevice is using 1.2 API])
 fi
 PKG_CHECK_MODULES(libplist, libplist >= 0.15)
 PKG_CHECK_MODULES(libzip, libzip >= 0.8)

--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -98,16 +98,26 @@ static void notifier(const char *notification)
 	notified = 1;
 }
 
-#ifdef HAVE_LIBIMOBILEDEVICE_1_1
+#if defined( HAVE_LIBIMOBILEDEVICE_1_2 )
+static void status_cb(plist_t command, plist_t status, void *unused)
+#elif defined( HAVE_LIBIMOBILEDEVICE_1_1 )
 static void status_cb(const char *operation, plist_t status, void *unused)
 #else
 static void status_cb(const char *operation, plist_t status)
 #endif
 {
+#if defined( HAVE_LIBIMOBILEDEVICE_1_2 )
+	if (status && command) {
+#else
 	if (status && operation) {
+#endif
 		plist_t npercent = plist_dict_get_item(status, "PercentComplete");
 		plist_t nstatus = plist_dict_get_item(status, "Status");
 		plist_t nerror = plist_dict_get_item(status, "Error");
+#if defined( HAVE_LIBIMOBILEDEVICE_1_2 )
+		char *operation = NULL;
+		instproxy_command_get_name(command, &operation);
+#endif
 		int percent = 0;
 		char *status_msg = NULL;
 		if (npercent) {
@@ -146,6 +156,11 @@ static void status_cb(const char *operation, plist_t status)
 			last_status = strdup(status_msg);
 			free(status_msg);
 		}
+#if defined( HAVE_LIBIMOBILEDEVICE_1_2 )
+		if (operation) {
+			free(operation);
+		}
+#endif
 	} else {
 		printf("%s: called with invalid data!\n", __func__);
 	}


### PR DESCRIPTION
Needed for iOS 8 support, AFAIK.

Tested against old work iPad 2 on 8.1.3