### PR TITLE
Don't consider Payload/.DS_Store as app folder

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -288,6 +288,10 @@ static int zip_get_app_directory(struct zip* zf, char** path)
 		if (name != NULL) {
 			/* check if we have a "Payload/.../" name */
 			len = strlen(name);
+
+			/* Skip "Payload/.DSStore" entry */
+			if (!strncmp(name, "Payload/.DS_Store", 17)) continue;
+
 			if (!strncmp(name, "Payload/", 8) && (len > 8)) {
 				/* locate the second directory delimiter */
 				const char* p = name + 8;


### PR DESCRIPTION
Hi. Unpacking/repacking an .ipa e.g. to resign it on OS X might add an .DS_Store folder, which then confuses iDeviceInstaller. The fix just skips this folder.