### PR TITLE
Issue #43: Fix libzip compile issues

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Installation
 ============
 
 To compile run:
-	./configure
+	./autogen.sh
 	make
 	sudo make install
 

--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -51,8 +51,11 @@
 
 #include <zip.h>
 
-#ifndef ZIP_CODEC_ENCODE
+#ifndef LIBZIP_VERSION
 // this is required for old libzip...
+// libzip 0.10 introduced the define for LIBZIP_VERSION (used by all later 
+// versions) and also introduced the declarations below.
+// If it's not there, assume we'll need these defines.
 #define zip_get_num_entries(x, y) zip_get_num_files(x)
 #define zip_int64_t ssize_t
 #define zip_uint64_t off_t


### PR DESCRIPTION
Modified the define check to look for LIBZIP_VERSION as opposed to ZIP_CODEC_ENCODE.  libzip 0.10 introduced LIBZIP_VERSION (which is also used by all later versions) and also introduced the defines that the guard handles.  ZIP_CODEC_ENCODE is no longer used by later libzip versions (e.g. 1.1.2) which was causing compilation errors.

Also, the config.ac has a check that libzip is >= 0.10 so this is mostly a moot point.