### PR TITLE
Fixed a type comparrison issue

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -907,7 +907,7 @@ run_again:
 					dstpath = NULL;
 
 					zip_uint64_t zfsize = 0;
-					while (zfsize < zs.size) {
+					while ((int)zfsize < (int)zs.size) {
 						zip_int64_t amount = zip_fread(zfile, buf, sizeof(buf));
 						if (amount == 0) {
 							break;


### PR DESCRIPTION
zfsize in comparrison to zs.size needs to be of type int to be compared. It previously was type int and unsigned long (I think)
I now casted the variables both to int fixing the issue.