### PR TITLE
Fix compile error with recent versions of libzip

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Installation
 ============
 
 To compile run:
-	./configure
+	./autogen.sh
 	make
 	sudo make install
 

--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -51,13 +51,6 @@
 
 #include <zip.h>
 
-#ifndef ZIP_CODEC_ENCODE
-// this is required for old libzip...
-#define zip_get_num_entries(x, y) zip_get_num_files(x)
-#define zip_int64_t ssize_t
-#define zip_uint64_t off_t
-#endif
-
 #define ITUNES_METADATA_PLIST_FILENAME "iTunesMetadata.plist"
 
 const char PKG_PATH[] = "PublicStaging";


### PR DESCRIPTION
This pull request supersedes #65 and #53, and fixes issues #43, #50, #66, and (probably) #55.
I prefer this change over just changing the condition on the #if line, since that line only selects versions of libzip that are disallowed by the configure script. See my notes on #43.
Also, as in pull #65, it also corrects the compile instructions in README.