### PR TITLE
Do not bail when notification is sent too early

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -330,7 +330,7 @@ static void idevice_wait_for_command_to_complete()
 
 	/* wait for command to complete */
 	while (wait_for_command_complete && !command_completed && !err_occurred
-		   && !notified && is_device_connected) {
+		   && is_device_connected) {
 		nanosleep(&ts, NULL);
 	}
 


### PR DESCRIPTION
I have seen cases where the notifier is sent when progress is at 40% (Install: VerifyingApplication (40%)). The loop bails out and the rest of the progress status is not shown. The notifier is probably sent by the phone, so it might be a bug from iOS.

Since there is a second loop for the notifier itself, maybe it makes sense.