### PR TITLE
Fix a hang on iOS 10.3.x

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -192,6 +192,17 @@ static void status_cb(plist_t command, plist_t status, void *unused)
 			}
 		}
 
+		/* get bundle identifier (used on iOS 10.3.x to indicate completion) */
+		char* bundle_identifier = NULL;
+		plist_t node = plist_dict_get_item(status, "CFBundleIdentifier");
+		if (node) {
+			plist_get_string_val(node, &bundle_identifier);
+		}
+
+		if (bundle_identifier) {
+			command_completed = 1;
+		}
+
 		/* get error if any */
 		char* error_name = NULL;
 		char* error_description = NULL;


### PR DESCRIPTION
On iOS 10.3, you don't receive a message with status `Complete` when installing an app. This means `ideviceinstaller` will just hang once installation has completed.

You do get a status message where the `CFBundleIdentifier` is echo'd back, and you can use that to determine installation has completed.