### PR TITLE
Fix get wrong app directory occasionally, when there are extra directory under Payload, taking "OnDemandResources" for example

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -329,6 +329,12 @@ static int zip_get_app_directory(struct zip* zf, char** path)
 
 				len = p - name + 1;
 
+				/* make sure app directory endwith .app */
+				if (len < 12 || strncmp(p - 4, ".app", 4))
+				{
+					continue;
+				}
+
 				if (path != NULL) {
 					free(*path);
 					*path = NULL;


### PR DESCRIPTION
Bug fix installer may fail to install ipa occasionally, when extra directory exist under Payload directory.