### PR TITLE
readme: install via package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Some key features are:
 
 ### Debian / Ubuntu Linux
 
+#### Installing ideviceinstaller via package manager
+
+```shell
+sudo apt install ideviceinstaller
+```
+
+#### Compiling ideviceinstaller from source
+
 First install all required dependencies and build tools:
 ```shell
 sudo apt-get install \


### PR DESCRIPTION
ideviceinstaller can also be installed via apt on debian/ubuntu.