### PR TITLE
Fix wrong exit code on specific output format (xml or json)

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -925,6 +925,7 @@ run_again:
 				free(buf);
 			}
 			plist_free(apps);
+			res = 0;
 			goto leave_cleanup;
 		}
 


### PR DESCRIPTION
fix [#155](https://github.com/libimobiledevice/ideviceinstaller/issues/155)