### PR TITLE
Enable large file support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,9 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([strdup strerror asprintf vasprintf])
 
+# Support large file
+AC_SYS_LARGEFILE
+
 # Check for lstat
 
 AC_MSG_CHECKING([whether lstat is available])


### PR DESCRIPTION
stat() will raise "value too large" error if the input file is larger than 2GB without 64-bit off_t.
MSYS UCRT64  need this marco to support large files.